### PR TITLE
Feature/spm use dependency

### DIFF
--- a/Argon2Swift.podspec
+++ b/Argon2Swift.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.name             = "Argon2Swift"
   spec.version          = "1.0.1"
   spec.summary          = "A Swift wrapper around the Argon2 reference implementation."
-  spec.swift_version = "5.0"
+  spec.swift_version    = "5.0"
 
   spec.description      = <<-DESC
     A Swift wrapper around the Argon2 Reference implementation, built for simplicity and ease
@@ -46,7 +46,7 @@ Pod::Spec.new do |spec|
   #  profile URL.
   #
 
-  spec.author             = { "Tejas Mehta" => "tmthecoder@gmail.com" }
+  spec.author           = { "Tejas Mehta" => "tmthecoder@gmail.com" }
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "argon2",
+        "repositoryURL": "https://github.com/P-H-C/phc-winner-argon2.git",
+        "state": {
+          "branch": "master",
+          "revision": "16d3df698db2486dde480b09a732bf9bf48599f9",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(
-            name: "Argon2", 
+            name: "argon2", 
             url: "https://github.com/P-H-C/phc-winner-argon2.git", .branch("master")
         )
     ],
@@ -24,7 +24,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Argon2Swift",
-            dependencies: ["Argon2"],
+            dependencies: ["argon2"],
             path: "Sources/Swift"),
         .testTarget(
             name: "Argon2SwiftTests",

--- a/Package.swift
+++ b/Package.swift
@@ -14,26 +14,14 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(
+            name: "Argon2", 
+            url: "https://github.com/P-H-C/phc-winner-argon2.git", .branch("master")
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "Argon2",
-            dependencies: [],
-            path: "Sources/Argon2",
-            exclude: [
-                "Sources/Argon2/kats",
-                "Sources/Argon2/vs2015",
-                "Sources/Argon2/src/blake2/blamka-round-opt.h",
-                "Sources/Argon2/src/run.c",
-                "Sources/Argon2/src/test.c",
-                "Sources/Argon2/src/opt.c",
-                "Sources/Argon2/src/bench.c",
-                "Sources/Argon2/src/genkat.c",
-                "Sources/Argon2/src/genkat.h"
-            ]),
         .target(
             name: "Argon2Swift",
             dependencies: ["Argon2"],

--- a/Sources/Modules/module.modulemap
+++ b/Sources/Modules/module.modulemap
@@ -1,4 +1,4 @@
-module Argon2 {
+module argon2 {
     header "../Argon2/include/argon2.h"
     export *
 }

--- a/Sources/Swift/Argon2Swift.swift
+++ b/Sources/Swift/Argon2Swift.swift
@@ -5,7 +5,7 @@
 
 
 import Foundation
-import Argon2
+import argon2
 
 /// Main class to handle all Argon2 hashing and verification
 /// ### Usage Example ###


### PR DESCRIPTION
Rather than declaring your own target for the C code, consider using the `dependency` feature, which points everything back to the original p-h-c repository now that there's a `Package.swift` [included over there](https://github.com/P-H-C/phc-winner-argon2/pull/313/files). As an added bonus, I linked the p-h-c README over to this repo, so people can find your Swift wrapper more easily!

You might be able to remove the modulemap and/or the entire submodule as well now, depending on how you want to manage your Xcode builds and CocoaPods.

Please note that I did not test these changes with CocoaPods, so it's possible that it might cause issues with that use case.